### PR TITLE
Dev docs

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -12,7 +12,7 @@ conda:
 build:
   os: ubuntu-22.04
   tools:
-    python: "3.11"
+    python: "mambaforge-4.10"
   jobs:
     # https://github.com/readthedocs/readthedocs.org/issues/4912#issuecomment-1143587902
     post_install:

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -30,6 +30,9 @@ build:
     # post_install:
     #   - poetry install
 
+conda:
+  environment: docs/docs_environment.yaml
+
 # Build documentation in the docs/ directory with Sphinx
 sphinx:
    configuration: docs/conf.py

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -12,7 +12,7 @@ conda:
 build:
   os: ubuntu-22.04
   tools:
-    python: "3.10"
+    python: "3.11"
   jobs:
     # https://github.com/readthedocs/readthedocs.org/issues/4912#issuecomment-1143587902
     post_install:

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -5,45 +5,20 @@
 # Required
 version: 2
 
+conda:
+  environment: docs/docs_environment.yaml
+
 # Set the version of Python and other tools you might need
 build:
-  os: ubuntu-20.04
+  os: ubuntu-22.04
   tools:
     python: "3.10"
-    # You can also specify other tool versions:
-    # nodejs: "16"
-    # rust: "1.55"
-    # golang: "1.17"
   jobs:
     # https://github.com/readthedocs/readthedocs.org/issues/4912#issuecomment-1143587902
     post_install:
       - cp -r ./notebooks ./docs/notebooks
-      # - pip install poetry==1.3.1
-      # - poetry config virtualenvs.create false
-      # - poetry install
 
-    # pre_create_environment: # reqs install with poetry https://github.com/readthedocs/readthedocs.org/issues/4912
-    #   - asdf plugin add poetry
-    #   - asdf install poetry latest
-    #   - asdf global poetry latest
-    #   - poetry config virtualenvs.create false
-    # post_install:
-    #   - poetry install
-
-conda:
-  environment: docs/docs_environment.yaml
 
 # Build documentation in the docs/ directory with Sphinx
 sphinx:
    configuration: docs/conf.py
-
-# If using Sphinx, optionally build your docs in additional formats such as PDF
-# formats:
-#    - pdf
-
-# Optionally declare the Python requirements required to build your docs
-# python:
-#    install:
-#    - requirements: docs/requirements.txt
-#    - method: pip
-#      path: .

--- a/docs/docs_environment.yaml
+++ b/docs/docs_environment.yaml
@@ -1,6 +1,7 @@
 name: docs_env
 channels:
   - defaults
+  - conda-forge
 dependencies:
   - python=3.10
   - sphinx

--- a/docs/docs_environment.yaml
+++ b/docs/docs_environment.yaml
@@ -1,0 +1,13 @@
+name: docs_env
+channels:
+  - defaults
+dependencies:
+  - python=3.10
+  - sphinx
+  - pip:
+    - furo
+    - sphinx==6.1.3
+    - sphinx-autoapi==2.0.0
+    - sphinx-autodoc-typehints==1.18.3
+    - nbsphinx==0.8.9
+    - m2r2==0.3.2


### PR DESCRIPTION
This patch updates the build environment from Ubuntu 20.04 to Ubuntu 22.04 and changes the Python tool from version 3.10 to mambaforge-4.10. It also removes unnecessary comments and code related to other tools like nodejs, rust, and golang. The patch also simplifies the post_install job to only copy notebooks into the docs directory. The Sphinx configuration remains the same. 

The second part of the patch introduces a new file that specifies the dependencies for the documentation environment, including Python 3.10, Sphinx, and several Sphinx-related packages installed via pip.