### PR TITLE
fix calibration_model/fld.py

### DIFF
--- a/sportslabkit/calibration_model/fld.py
+++ b/sportslabkit/calibration_model/fld.py
@@ -53,7 +53,8 @@ class SimpleContourCalibrator(BaseCalibrationModel):
         hull = cv2.convexHull(contour)
         return hull
     
-    def _get_first_point(self, hull):
+    def _get_left_top_point(self, hull):
+        """Find the nearest point from the upper left corner."""
         sorted_hull = sorted(hull, key=lambda x:x[0][0]*x[0][0] + x[0][1]*x[0][1])
         return sorted_hull[0][0]
 

--- a/sportslabkit/calibration_model/fld.py
+++ b/sportslabkit/calibration_model/fld.py
@@ -52,6 +52,10 @@ class SimpleContourCalibrator(BaseCalibrationModel):
     def _approximate_hull(self, contour):
         hull = cv2.convexHull(contour)
         return hull
+    
+    def _get_first_point(self, hull):
+        sorted_hull = sorted(hull, key=lambda x:x[0][0]*x[0][0] + x[0][1]*x[0][1])
+        return sorted_hull[0][0]
 
     def _farthest_point_from(self, reference_point, point_list):
         """Find the point in 'point_list' that is farthest from 'reference_point'."""
@@ -66,7 +70,7 @@ class SimpleContourCalibrator(BaseCalibrationModel):
 
     def _approximate_quad(self, hull):
         """Approximate a convex hull to a quadrilateral by considering most distant points."""
-        first_point = hull[0][0]
+        first_point = self._get_first_point(hull)
         second_point = self._farthest_point_from(first_point, hull)
 
         max_distance = 0

--- a/sportslabkit/calibration_model/fld.py
+++ b/sportslabkit/calibration_model/fld.py
@@ -53,7 +53,7 @@ class SimpleContourCalibrator(BaseCalibrationModel):
         hull = cv2.convexHull(contour)
         return hull
     
-    def _get_left_top_point(self, hull):
+    def _get_upper_left_courner(self, hull):
         """Find the nearest point from the upper left corner."""
         sorted_hull = sorted(hull, key=lambda x:x[0][0]*x[0][0] + x[0][1]*x[0][1])
         return sorted_hull[0][0]
@@ -71,7 +71,7 @@ class SimpleContourCalibrator(BaseCalibrationModel):
 
     def _approximate_quad(self, hull):
         """Approximate a convex hull to a quadrilateral by considering most distant points."""
-        first_point = self._get_first_point(hull)
+        first_point = self._get_upper_left_corner(hull)
         second_point = self._farthest_point_from(first_point, hull)
 
         max_distance = 0


### PR DESCRIPTION
_approximate_quad内のfirst_pointがコートの左上を示すように、新たに_get_first_point関数を作成しました。

変更前
![cal__1](https://github.com/AtomScott/SportsLabKit/assets/129936839/b40ce848-4edb-4d39-8724-b7620162b935)

変更後
![cal__0](https://github.com/AtomScott/SportsLabKit/assets/129936839/dfe9c1fa-f58d-4548-8f0e-0ecc5bd47c5f)

また、サンプルデータのサッカーコートの画像でも問題はなさそうです。
![cal_00](https://github.com/AtomScott/SportsLabKit/assets/129936839/99677598-8c49-45d7-96d1-3f192897dad2)
